### PR TITLE
feat: 44450: add describe listerner attributes permission

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -47,7 +47,8 @@ data "aws_iam_policy_document" "lb_controller" {
       "elasticloadbalancing:DescribeTargetGroups",
       "elasticloadbalancing:DescribeTargetGroupAttributes",
       "elasticloadbalancing:DescribeTargetHealth",
-      "elasticloadbalancing:DescribeTags"
+      "elasticloadbalancing:DescribeTags",
+      "elasticloadbalancing:DescribeListenerAttributes"
     ]
     resources = [
       "*",


### PR DESCRIPTION
New EKS 1.32 version now require the elasticloadbalancing:DescribeListenerAttributes else the ingress will fail to connect to its load balancer on aws